### PR TITLE
Added options to facilitate customization of chart colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ options:
   --pady LINES    Vertical padding of the chart. Defaults to 4.
   --short         Short output, prints the last price only.
   --nocolor       Prints chart with no color.
+  --upcolor COLOR    Color of positive candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to green.
+  --downcolor COLOR  Color of negative candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to red.
   -v              Toggle verbosity.
   --version       Print tstock version.
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ options:
   --pady LINES    Vertical padding of the chart. Defaults to 4.
   --short         Short output, prints the last price only.
   --nocolor       Prints chart with no color.
-  --upcolor COLOR    Color of positive candles. Valid values are 'green', 'red', or 'blue'. Defaults to green.
-  --downcolor COLOR  Color of negative candles. Valid values are 'green', 'red', or 'blue'. Defaults to red.
+  --upcolor COLOR    Color of positive candlesticks. Valid values are 'green', 'red', or 'blue'. Defaults to green.
+  --downcolor COLOR  Color of negative candlesticks. Valid values are 'green', 'red', or 'blue'. Defaults to red.
   -v              Toggle verbosity.
   --version       Print tstock version.
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ options:
   --pady LINES    Vertical padding of the chart. Defaults to 4.
   --short         Short output, prints the last price only.
   --nocolor       Prints chart with no color.
-  --upcolor COLOR    Color of positive candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to green.
-  --downcolor COLOR  Color of negative candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to red.
+  --upcolor COLOR    Color of positive candles. Valid values are 'green', 'red', or 'blue'. Defaults to green.
+  --downcolor COLOR  Color of negative candles. Valid values are 'green', 'red', or 'blue'. Defaults to red.
   -v              Toggle verbosity.
   --version       Print tstock version.
 

--- a/tstock/core.py
+++ b/tstock/core.py
@@ -314,6 +314,12 @@ def draw_graph(opts: dict):
     intraday = 'min' in interval
     candlesticks = get_candlesticks(opts)
     nocolor = opts["nocolor"]
+    upcolor = opts["upcolor"]
+    downcolor = opts["downcolor"]
+
+    ANSI_colors = {"green" : "\x1b[32m",
+                    "red" : "\x1b[31m",
+                    "blue" : "\x1b[34m"}
 
     max_x = len(candlesticks) + pad_x * 2 + 2
 
@@ -367,7 +373,7 @@ def draw_graph(opts: dict):
         # Draw open/close
         # Positive day, stock went up
         if c[0] < c[3]:
-            column_colors[shifted_i] = "\x1b[32m"  # ANSI green
+            column_colors[shifted_i] = ANSI_colors[upcolor]
             tmp = translated_low
             translated_low = translated_high
             translated_high = tmp
@@ -375,7 +381,7 @@ def draw_graph(opts: dict):
                 chart[y, shifted_i] = "█"
         # Negative day, stock went down
         else:
-            column_colors[shifted_i] = "\x1b[31m"  # ANSI red
+            column_colors[shifted_i] = ANSI_colors[downcolor]
             for y in range(translated_open, translated_close + 1):
                 chart[y, shifted_i] = "█"
 

--- a/tstock/parse.py
+++ b/tstock/parse.py
@@ -100,7 +100,7 @@ def parse_args(parser: argparse.ArgumentParser):
             sys.exit(1)
     if args.downcolor:
         if args.downcolor not in ['green', 'red', 'blue']:
-            print(f"Invalid color {args.upcolor}.")
+            print(f"Invalid color {args.downcolor}.")
             sys.exit(1)
     
 
@@ -194,10 +194,10 @@ def get_args():
         help="Prints chart with no color.")
 
     arg.add_argument("--upcolor", metavar="COLOR", type=str, default="green",
-        help="Color of positive candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to green.")
+        help="Color of positive candles. Valid values are 'green', 'red', or 'blue'. Defaults to green.")
     
     arg.add_argument("--downcolor", metavar="COLOR", type=str, default="red",
-        help="Color of negative candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to red.")
+        help="Color of negative candles. Valid values are 'green', 'red', or 'blue'. Defaults to red.")
 
     arg.add_argument("-v", action="store_true",
         help="Toggle verbosity.")

--- a/tstock/parse.py
+++ b/tstock/parse.py
@@ -194,10 +194,10 @@ def get_args():
         help="Prints chart with no color.")
 
     arg.add_argument("--upcolor", metavar="COLOR", type=str, default="green",
-        help="Color of positive candles. Valid values are 'green', 'red', or 'blue'. Defaults to green.")
+        help="Color of positive candlesticks. Valid values are 'green', 'red', or 'blue'. Defaults to green.")
     
     arg.add_argument("--downcolor", metavar="COLOR", type=str, default="red",
-        help="Color of negative candles. Valid values are 'green', 'red', or 'blue'. Defaults to red.")
+        help="Color of negative candlesticks. Valid values are 'green', 'red', or 'blue'. Defaults to red.")
 
     arg.add_argument("-v", action="store_true",
         help="Toggle verbosity.")

--- a/tstock/parse.py
+++ b/tstock/parse.py
@@ -36,6 +36,8 @@ def parse_args(parser: argparse.ArgumentParser):
         "pad_y": args.pady,
         "verbose": args.v,
         "nocolor": args.nocolor,
+        "upcolor": args.upcolor,
+        "downcolor": args.downcolor,
         "wisdom": args.w,
         "intraday": 'min' in args.t,
         "chart_only": args.chart,
@@ -91,6 +93,17 @@ def parse_args(parser: argparse.ArgumentParser):
             print(f"Invalid class value {opts['asset_class']}.")
             sys.exit(1)
     
+    # Validate arguments for upcolor and downcolor
+    if args.upcolor:
+        if args.upcolor not in ['green', 'red', 'blue']:
+            print(f"Invalid color {args.upcolor}.")
+            sys.exit(1)
+    if args.downcolor:
+        if args.downcolor not in ['green', 'red', 'blue']:
+            print(f"Invalid color {args.upcolor}.")
+            sys.exit(1)
+    
+
     # Handle currency symbol for -c option
     if args.c != 'USD' and opts['asset_class'] != 'crypto':
         print("Warning: the -c flag is only supported for asset type 'crypto'. It will be ignored.")
@@ -179,6 +192,12 @@ def get_args():
 
     arg.add_argument("--nocolor", action="store_true",
         help="Prints chart with no color.")
+
+    arg.add_argument("--upcolor", metavar="COLOR", type=str, default="green",
+        help="Color of positive candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to green.")
+    
+    arg.add_argument("--downcolor", metavar="COLOR", type=str, default="red",
+        help="Color of negative candles. Valid numbers are 'green', 'red', or 'blue'. Defaults to red.")
 
     arg.add_argument("-v", action="store_true",
         help="Toggle verbosity.")


### PR DESCRIPTION
Not every market generally uses green for up and red for down. For instance, China (excluding Hong Kong) and Japan conventionally use red for up and green for down, and South Korea tends to use red for up and blue for down. Investors accustomed to the prevalent chart colors of those markets (including me) may find it difficult to adapt to the "green up, red down" style. Therefore it would be nice to allow users to customize chart colors.

I've allowed users to set the colors of positive and negative candlesticks as green, red, or blue by adding options --upcolor and --downcolor. This caters to the needs of investors from China (excluding Hong Kong), Japan, and South Korea.